### PR TITLE
Fix bug in max retry counting

### DIFF
--- a/src/main/java/org/scijava/io/http/HTTPHandle.java
+++ b/src/main/java/org/scijava/io/http/HTTPHandle.java
@@ -222,8 +222,8 @@ public class HTTPHandle extends AbstractSeekableStreamHandle<HTTPLocation> {
 				// counts the number of responses (previous tries
 				private boolean aboveMaxRetries(final Response response) {
 					int rescount = 1;
-					Response r;
-					while ((r = response.priorResponse()) != null &&
+					Response r = response;
+					while ((r = r.priorResponse()) != null &&
 						rescount < MAX_RETRIES)
 					{
 						rescount++;


### PR DESCRIPTION
The prior responses were not cascading up the chain.

@gab1one What do you think? Note that I did not test it.