### PR TITLE
Update OKHTTP dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scijava-io-http</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
+	<version>0.2.2-SNAPSHOT</version>
 
 	<name>SciJava I/O: HTTP</name>
 	<description>SciJava I/O support for HTTP/HTTPS.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>28.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -98,8 +98,7 @@
 		<license.copyrightOwners>KNIME GmbH and Board of Regents of the University
 of Wisconsin-Madison.</license.copyrightOwners>
 
-		<scijava-common.version>2.76.0</scijava-common.version>
-		<okhttp.version>3.6.0</okhttp.version>
+		<okhttp.version>4.7.2</okhttp.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>

--- a/src/test/java/org/scijava/io/http/HTTPLocationTest.java
+++ b/src/test/java/org/scijava/io/http/HTTPLocationTest.java
@@ -37,8 +37,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.junit.Test;
-import org.scijava.io.http.HTTPLocation;
-
 import okhttp3.HttpUrl;
 
 /**


### PR DESCRIPTION
@gab1one, @ctrueden :
SNT uses okhttp a lot. We are currently using [v4.7.2](https://github.com/morphonets/SNT/blob/31bac4762f23023d8f2c327e1ca365977dbf3ed8/pom.xml#L255). There is a funky issue  in _some combinations_ of update sites (I really didn't have time to look into it: it was hard to understand how it was happening) the okhttp jar from our update site does not get downloaded: the updater considers the okhttp from scijava-io-http instead. This attempts to bring them into sync. Eitherway, you guys are using a 3year old release, so updating is certainly beneficial!